### PR TITLE
Fix array check for node-webkit

### DIFF
--- a/node/ejdb.js
+++ b/node/ejdb.js
@@ -163,7 +163,7 @@ EJDB.prototype.save = function(cname, jsarr, opts, cb) {
     if (!jsarr) {
         return [];
     }
-    if (jsarr.constructor !== Array) {
+    if (! (jsarr.constructor.name == "Array")) {
         jsarr = [jsarr];
     }
     if (typeof opts == "function") {


### PR DESCRIPTION
This seems to be a very weird bug, but when using ejdb with node-webkit, .constructor === Array
returns false for actual arrays. This is because node-webkit runs ejdb as a node 
module in a different JavaScript context (WebKit context), so there are actually
two unique objects that represent any constructor (one of each scope). So instead
of comparing if .constructor references to the same object as "Array", we just check
if the name of the constructor is "Array".
