### PR TITLE
Negate $elemMatch

### DIFF
--- a/tcejdb/ejdb.c
+++ b/tcejdb/ejdb.c
@@ -2084,7 +2084,7 @@ static bool _qrybsrecurrmatch(EJQF *qf, FFPCTX *ffpctx, int currpos) {
                 bson_iterator sit2;
                 BSON_ITERATOR_SUBITERATOR(&sit, &sit2);
                 ffpctx->input = &sit2;
-                if (_qrybsrecurrmatch(qf, ffpctx, currpos)) {
+                if (_qrybsrecurrmatch(qf, ffpctx, currpos) != qf->negate) {
                     bool ret = true;
                     if (qf->elmatchgrp > 0 && qf->elmatchpos == currpos) { //$elemMatch matching group exists at right place
                         for (int i = TCLISTNUM(qf->q->qflist) - 1; i >= 0; --i) {
@@ -4510,6 +4510,8 @@ static int _parse_qobj_impl(EJDB *jb, EJQ *q, bson_iterator *it, TCLIST *qlist, 
             qf.elmatchgrp = pqf->elmatchgrp;
             qf.elmatchpos = pqf->elmatchpos;
             qf.flags = pqf->flags;
+            if(elmatchgrp > 0)
+                qf.negate = pqf->negate;
         }
 
         if (!isckey) {

--- a/tcejdb/ejdb.c
+++ b/tcejdb/ejdb.c
@@ -2069,57 +2069,68 @@ static bool _qrybsrecurrmatch(EJQF *qf, FFPCTX *ffpctx, int currpos) {
     assert(qf && ffpctx && ffpctx->stopnestedarr);
     bson_type bt = bson_find_fieldpath_value3(ffpctx);
     if (bt == BSON_ARRAY && ffpctx->stopos < ffpctx->fplen) { //a bit of complicated code  in this case =)
-        //we just stepped in some array in middle of our fieldpath, so have to perform recusive nested iterations
+        //we just stepped in some array in middle of our fieldpath, so have to perform recursive nested iterations
         //$elemMatch active in this context
         while (ffpctx->fpath[ffpctx->stopos] == '.' && ffpctx->stopos < ffpctx->fplen) ffpctx->stopos++;
         ffpctx->fplen = ffpctx->fplen - ffpctx->stopos;
         assert(ffpctx->fplen > 0);
         ffpctx->fpath = ffpctx->fpath + ffpctx->stopos;
         currpos += ffpctx->stopos; //adjust cumulative field position
+
         bson_iterator sit;
         BSON_ITERATOR_SUBITERATOR(ffpctx->input, &sit);
-        int c = 0;
-        while ((bt = bson_iterator_next(&sit)) != BSON_EOO) {
-            if (bt == BSON_OBJECT || bt == BSON_ARRAY) {
-                bson_iterator sit2;
-                BSON_ITERATOR_SUBITERATOR(&sit, &sit2);
-                ffpctx->input = &sit2;
-                if (_qrybsrecurrmatch(qf, ffpctx, currpos) != qf->negate) {
-                    bool ret = true;
-                    if (qf->elmatchgrp > 0 && qf->elmatchpos == currpos) { //$elemMatch matching group exists at right place
-                        for (int i = TCLISTNUM(qf->q->qflist) - 1; i >= 0; --i) {
-                            EJQF *eqf = TCLISTVALPTR(qf->q->qflist, i);
-                            if (eqf == qf || (eqf->mflags & EJFEXCLUDED) || eqf->elmatchgrp != qf->elmatchgrp) {
-                                continue;
-                            }
-                            eqf->mflags |= EJFEXCLUDED;
-                            BSON_ITERATOR_SUBITERATOR(&sit, &sit2);
-                            FFPCTX nffpctx = *ffpctx;
-                            nffpctx.fplen = eqf->fpathsz - eqf->elmatchpos;
-                            if (nffpctx.fplen <= 0) { //should never happen if query construction is correct
-                                assert(false);
-                                ret = false;
-                                break;
-                            }
-                            nffpctx.fpath = eqf->fpath + eqf->elmatchpos;
-                            nffpctx.input = &sit2;
-                            nffpctx.stopos = 0;
-                            if (!_qrybsrecurrmatch(eqf, &nffpctx, eqf->elmatchpos)) {
-                                ret = false;
-                                break;
-                            }
-                        }
-                    }
-                    if (ret) {
-                        _qrysetarrayidx(ffpctx, qf, (currpos - 1), c);
-                    }
+        for (int arr_idx = 0;(bt = bson_iterator_next(&sit)) != BSON_EOO; ++arr_idx) {
+            if (bt != BSON_OBJECT && bt != BSON_ARRAY)
+                continue;
 
-                    return ret;
+            bson_iterator sit2;
+            BSON_ITERATOR_SUBITERATOR(&sit, &sit2);
+
+            ffpctx->input = &sit2;
+
+            // Match using context initialised above.
+            if (_qrybsrecurrmatch(qf, ffpctx, currpos) == qf->negate) {
+                continue;
+            }
+
+            bool ret = true;
+            if (qf->elmatchgrp > 0 && qf->elmatchpos == currpos) { //$elemMatch matching group exists at right place
+                // Match all sub-queries on current field pos. Early exit (break) on failure.
+                for (int i = TCLISTNUM(qf->q->qflist) - 1; i >= 0; --i) {
+                    EJQF *eqf = TCLISTVALPTR(qf->q->qflist, i);
+                    if (eqf == qf || (eqf->mflags & EJFEXCLUDED) || eqf->elmatchgrp != qf->elmatchgrp) {
+                        continue;
+                    }
+                    eqf->mflags |= EJFEXCLUDED;
+                    BSON_ITERATOR_SUBITERATOR(&sit, &sit2);
+                    FFPCTX nffpctx = *ffpctx;
+                    nffpctx.fplen = eqf->fpathsz - eqf->elmatchpos;
+                    if (nffpctx.fplen <= 0) { //should never happen if query construction is correct
+                        assert(false);
+                        ret = false;
+                        break;
+                    }
+                    nffpctx.fpath = eqf->fpath + eqf->elmatchpos;
+                    nffpctx.input = &sit2;
+                    nffpctx.stopos = 0;
+
+                    // Match sub-query at current field pos.
+                    // Ignores outer negate (qf) on inner query (eqf).
+                    if (_qrybsrecurrmatch(eqf, &nffpctx, eqf->elmatchpos) == qf->negate) {
+                        // Skip all remaining sub-queries on this field. Go to next element, if any.
+                        ret = false;
+                        break;
+                    }
                 }
-                ++c;
+            }
+            if (ret) {
+                _qrysetarrayidx(ffpctx, qf, (currpos - 1), arr_idx);
+                // Only return success at this point.
+                // An failure here may precede a later success so proceed to next element, if any.
+                return ret != qf->negate;
             }
         }
-        return false;
+        return qf->negate;
     } else {
         if (bt == BSON_EOO || bt == BSON_UNDEFINED || bt == BSON_NULL) {
             return qf->negate; //Field missing

--- a/tcejdb/testejdb/t2.c
+++ b/tcejdb/testejdb/t2.c
@@ -58,11 +58,6 @@ void testAddData() {
     bson_append_string(&a1, "foo2", "bar2");
     bson_append_string(&a1, "foo3", "bar3");
     bson_append_finish_object(&a1);
-    bson_append_start_object(&a1, "1");
-    bson_append_string(&a1, "foo", "bar");
-    bson_append_string(&a1, "foo2", "bar3");
-    bson_append_finish_object(&a1);
-    bson_append_int(&a1, "2", 333);
     bson_append_finish_array(&a1); //EOF complexarr
     CU_ASSERT_FALSE_FATAL(a1.err);
     bson_finish(&a1);
@@ -81,6 +76,13 @@ void testAddData() {
     bson_append_string(&a1, "zip", "630090");
     bson_append_string(&a1, "street", "Pirogova");
     bson_append_finish_object(&a1);
+    bson_append_start_array(&a1, "complexarr");
+    bson_append_start_object(&a1, "0");
+    bson_append_string(&a1, "foo", "bar");
+    bson_append_string(&a1, "foo2", "bar3");
+    bson_append_finish_object(&a1);
+    bson_append_int(&a1, "1", 333);
+    bson_append_finish_array(&a1); //EOF complexarr
     bson_append_start_array(&a1, "labels");
     bson_append_string(&a1, "0", "red");
     bson_append_string(&a1, "1", "green");
@@ -3725,7 +3727,7 @@ void testFindInComplexArray() {
     TCLIST *q1res = ejdbqryexecute(coll, q1, &count, 0, log);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
     //fprintf(stderr, "%s", TCXSTRPTR(log));
-    CU_ASSERT_EQUAL(count, 1);
+    CU_ASSERT_EQUAL(count, 2);
     for (int i = 0; i < TCLISTNUM(q1res); ++i) {
         CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
     }
@@ -3737,7 +3739,7 @@ void testFindInComplexArray() {
 
     //Check matching positional element
     bson_init_as_query(&bsq1);
-    bson_append_string(&bsq1, "complexarr.1.foo", "bar");
+    bson_append_string(&bsq1, "complexarr.0.foo", "bar");
     bson_finish(&bsq1);
     q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
@@ -3745,9 +3747,9 @@ void testFindInComplexArray() {
     q1res = ejdbqryexecute(coll, q1, &count, 0, log);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
     //fprintf(stderr, "\n%s", TCXSTRPTR(log));
-    CU_ASSERT_EQUAL(count, 1);
+    CU_ASSERT_EQUAL(count, 2);
     for (int i = 0; i < TCLISTNUM(q1res); ++i) {
-        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.1.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
     }
 
     bson_destroy(&bsq1);
@@ -3757,7 +3759,7 @@ void testFindInComplexArray() {
 
     //Check simple el
     bson_init_as_query(&bsq1);
-    bson_append_int(&bsq1, "complexarr.2", 333);
+    bson_append_int(&bsq1, "complexarr.1", 333);
     bson_finish(&bsq1);
     q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
@@ -3767,7 +3769,7 @@ void testFindInComplexArray() {
     //fprintf(stderr, "\n%s", TCXSTRPTR(log));
     CU_ASSERT_EQUAL(count, 1);
     for (int i = 0; i < TCLISTNUM(q1res); ++i) {
-        CU_ASSERT_FALSE(bson_compare_long(333, TCLISTVALPTR(q1res, i), "complexarr.2"));
+        CU_ASSERT_FALSE(bson_compare_long(333, TCLISTVALPTR(q1res, i), "complexarr.1"));
     }
     bson_destroy(&bsq1);
     tclistdel(q1res);
@@ -3786,7 +3788,7 @@ void testFindInComplexArray() {
     //fprintf(stderr, "\n%s", TCXSTRPTR(log));
     CU_ASSERT_EQUAL(count, 1);
     for (int i = 0; i < TCLISTNUM(q1res); ++i) {
-        CU_ASSERT_FALSE(bson_compare_long(333, TCLISTVALPTR(q1res, i), "complexarr.2"));
+        CU_ASSERT_FALSE(bson_compare_long(333, TCLISTVALPTR(q1res, i), "complexarr.1"));
     }
     bson_destroy(&bsq1);
     tclistdel(q1res);
@@ -3805,7 +3807,7 @@ void testFindInComplexArray() {
     log = tcxstrnew();
     q1res = ejdbqryexecute(coll, q1, &count, 0, log);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
-    CU_ASSERT_EQUAL(count, 1);
+    CU_ASSERT_EQUAL(count, 2);
     bson_destroy(&bsq1);
     tclistdel(q1res);
     tcxstrdel(log);
@@ -3873,6 +3875,7 @@ void test$elemMatch() {
     CU_ASSERT_EQUAL(count, 1);
     //fprintf(stderr, "%s", TCXSTRPTR(log));
     for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Антонов", TCLISTVALPTR(q1res, i), "name"));
         CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
         CU_ASSERT_FALSE(bson_compare_string("bar2", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
         CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo3"));
@@ -3897,7 +3900,12 @@ void test$elemMatch() {
     q1res = ejdbqryexecute(coll, q1, &count, 0, log);
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
     //fprintf(stderr, "%s", TCXSTRPTR(log));
-    CU_ASSERT_EQUAL(count, 0);
+    CU_ASSERT_EQUAL(count, 1);
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Адаманский", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
+    }
     bson_destroy(&bsq1);
     tclistdel(q1res);
     tcxstrdel(log);
@@ -3915,6 +3923,82 @@ void test$elemMatch() {
     CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
     //fprintf(stderr, "%s", TCXSTRPTR(log));
     CU_ASSERT_EQUAL(count, 1);
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Адаманский", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
+    }
+
+    bson_destroy(&bsq1);
+    tclistdel(q1res);
+    tcxstrdel(log);
+    ejdbquerydel(q1);
+}
+
+void test$not$elemMatch() {
+    //{complexarr : {$elemMatch : {foo : 'bar', foo2 : 'bar2', foo3 : 'bar3'}}}
+    EJCOLL *coll = ejdbcreatecoll(jb, "contacts", NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(coll);
+    bson bsq1;
+    bson_init_as_query(&bsq1);
+    bson_append_start_object(&bsq1, "complexarr");
+    bson_append_start_object(&bsq1, "$not");
+    bson_append_start_object(&bsq1, "$elemMatch");
+    bson_append_string(&bsq1, "foo", "bar");
+    bson_append_string(&bsq1, "foo2", "bar2");
+    bson_append_string(&bsq1, "foo3", "bar3");
+    bson_append_finish_object(&bsq1);//$elemMatch
+    bson_append_finish_object(&bsq1);//$not
+    //include $exists to exclude documents without complexarr
+    bson_append_bool(&bsq1, "$exists", true);
+    bson_append_finish_object(&bsq1);//complexarr
+    bson_finish(&bsq1);
+    CU_ASSERT_FALSE_FATAL(bsq1.err);
+
+    EJQ *q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
+    uint32_t count = 0;
+    TCXSTR *log = tcxstrnew();
+    TCLIST *q1res = ejdbqryexecute(coll, q1, &count, 0, log);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
+
+    CU_ASSERT_EQUAL(count, 1);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Адаманский", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
+    }
+    bson_destroy(&bsq1);
+    tclistdel(q1res);
+    tcxstrdel(log);
+    ejdbquerydel(q1);
+
+    bson_init_as_query(&bsq1);
+    bson_append_start_object(&bsq1, "complexarr");
+    bson_append_start_object(&bsq1, "$not");
+    bson_append_start_object(&bsq1, "$elemMatch");
+    bson_append_string(&bsq1, "foo", "bar");
+    bson_append_string(&bsq1, "foo2", "bar3");
+    bson_append_finish_object(&bsq1);//$elemMatch
+    bson_append_finish_object(&bsq1);//$not
+    bson_append_bool(&bsq1, "$exists", true);
+    bson_append_finish_object(&bsq1);
+    bson_finish(&bsq1);
+    CU_ASSERT_FALSE_FATAL(bsq1.err);
+    q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
+    log = tcxstrnew();
+    q1res = ejdbqryexecute(coll, q1, &count, 0, log);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    CU_ASSERT_EQUAL(count, 1);
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Антонов", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar2", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo3"));
+    }
     bson_destroy(&bsq1);
     tclistdel(q1res);
     tcxstrdel(log);
@@ -4992,6 +5076,7 @@ int main() {
             (NULL == CU_add_test(pSuite, "test$pull", test$pull)) ||
             (NULL == CU_add_test(pSuite, "testFindInComplexArray", testFindInComplexArray)) ||
             (NULL == CU_add_test(pSuite, "test$elemMatch", test$elemMatch)) ||
+            (NULL == CU_add_test(pSuite, "test$not$elemMatch", test$not$elemMatch)) ||
             (NULL == CU_add_test(pSuite, "testTicket16", testTicket16)) ||
             (NULL == CU_add_test(pSuite, "test$upsert", test$upsert)) ||
             (NULL == CU_add_test(pSuite, "testPrimitiveCases1", testPrimitiveCases1)) ||

--- a/tcejdb/testejdb/t2.c
+++ b/tcejdb/testejdb/t2.c
@@ -3912,6 +3912,35 @@ void test$elemMatch() {
     ejdbquerydel(q1);
 
     bson_init_as_query(&bsq1);
+    bson_append_start_object(&bsq1, "complexarr");
+    bson_append_start_object(&bsq1, "$elemMatch");
+    bson_append_string(&bsq1, "foo", "bar");
+    bson_append_start_object(&bsq1, "foo2");
+    bson_append_string(&bsq1, "$not", "bar3");
+    bson_append_finish_object(&bsq1);
+    bson_append_finish_object(&bsq1);
+    bson_append_finish_object(&bsq1);
+    bson_finish(&bsq1);
+    CU_ASSERT_FALSE_FATAL(bsq1.err);
+    q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
+    log = tcxstrnew();
+    q1res = ejdbqryexecute(coll, q1, &count, 0, log);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    CU_ASSERT_EQUAL(count, 1);
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Антонов", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar2", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo3"));
+    }
+    bson_destroy(&bsq1);
+    tclistdel(q1res);
+    tcxstrdel(log);
+    ejdbquerydel(q1);
+
+    bson_init_as_query(&bsq1);
     bson_append_string(&bsq1, "complexarr.foo", "bar");
     bson_append_string(&bsq1, "complexarr.foo2", "bar3");
     bson_finish(&bsq1);
@@ -3998,6 +4027,37 @@ void test$not$elemMatch() {
         CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
         CU_ASSERT_FALSE(bson_compare_string("bar2", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
         CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo3"));
+    }
+    bson_destroy(&bsq1);
+    tclistdel(q1res);
+    tcxstrdel(log);
+    ejdbquerydel(q1);
+
+    //ensure correct behaviour of double negative
+    bson_init_as_query(&bsq1);
+    bson_append_start_object(&bsq1, "complexarr");
+    bson_append_start_object(&bsq1, "$not");
+    bson_append_start_object(&bsq1, "$elemMatch");
+    bson_append_string(&bsq1, "foo", "bar");
+    bson_append_start_object(&bsq1, "foo2");
+    bson_append_string(&bsq1, "$not", "bar3");
+    bson_append_finish_object(&bsq1);
+    bson_append_finish_object(&bsq1);
+    bson_append_finish_object(&bsq1);
+    bson_append_finish_object(&bsq1);
+    bson_finish(&bsq1);
+    CU_ASSERT_FALSE_FATAL(bsq1.err);
+    q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1);
+    log = tcxstrnew();
+    q1res = ejdbqryexecute(coll, q1, &count, 0, log);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(q1res);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    CU_ASSERT_EQUAL(count, 1);
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        CU_ASSERT_FALSE(bson_compare_string("Адаманский", TCLISTVALPTR(q1res, i), "name"));
+        CU_ASSERT_FALSE(bson_compare_string("bar", TCLISTVALPTR(q1res, i), "complexarr.0.foo"));
+        CU_ASSERT_FALSE(bson_compare_string("bar3", TCLISTVALPTR(q1res, i), "complexarr.0.foo2"));
     }
     bson_destroy(&bsq1);
     tclistdel(q1res);


### PR DESCRIPTION
Enable ability to negate (with outer $not) an $elemMatch query. This will result in matching documents which do not contain a matching array, including those with no array.
Appropriate tests have been added. Some of the existing tests and data had to be modified to adequately test both this change and the existing $elemMatch functionality.