### PR TITLE
#127 Handling int64_t values and query on Windows

### DIFF
--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -2037,7 +2037,7 @@ int bson_compare_string(const char *cv, const void *bsdata, const char *fpath) {
     return res;
 }
 
-int bson_compare_long(long cv, const void *bsdata, const char *fpath) {
+int bson_compare_long(const int64_t cv, const void *bsdata, const char *fpath) {
     bson *bs1 = bson_create();
     bson_init(bs1);
     bson_append_long(bs1, "$", cv);

--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -1188,7 +1188,7 @@ EJDB_EXPORT int bson_compare(const void *bsdata1, const void *bsdata2, const cha
 EJDB_EXPORT int bson_compare_fpaths(const void *bsdata1, const void *bsdata2, const char *fpath1, int fplen1, const char *fpath2, int fplen2);
 EJDB_EXPORT int bson_compare_it_current(const bson_iterator *it1, const bson_iterator *it2);
 EJDB_EXPORT int bson_compare_string(const char* cv, const void *bsdata, const char *fpath);
-EJDB_EXPORT int bson_compare_long(long cv, const void *bsdata, const char *fpath);
+EJDB_EXPORT int bson_compare_long(const int64_t cv, const void *bsdata, const char *fpath);
 EJDB_EXPORT int bson_compare_double(double cv, const void *bsdata, const char *fpath);
 EJDB_EXPORT int bson_compare_bool(bson_bool_t cv, const void *bsdata, const char *fpath);
 

--- a/src/ejdb/ejdb.c
+++ b/src/ejdb/ejdb.c
@@ -5035,7 +5035,8 @@ static int _parse_qobj_impl(EJDB *jb, EJQ *q, bson_iterator *it, TCLIST *qlist, 
                 if (ftype == BSON_LONG || ftype == BSON_INT || ftype == BSON_DATE) {
                     qf.exprlongval = bson_iterator_long(it);
                     qf.exprdblval = qf.exprlongval;
-                    qf.expr = tcsprintf("%ld", qf.exprlongval);
+                    // 2015-04-14: Change to use standard format string for int64_t
+                    qf.expr = tcsprintf("%" PRId64, qf.exprlongval);
                 } else {
                     qf.exprdblval = bson_iterator_double(it);
                     qf.exprlongval = (int64_t) qf.exprdblval;


### PR DESCRIPTION
Here are my changes to handling int64_t query.  Made change to _parse_qobj_impl() to use printf format (cross-platform), change bson_compare_long() from long to int64_t, and added test case "testQuery28" to ejdbtest2.  