### PR TITLE
Feature to query for symbol objects using strings (see #129)

### DIFF
--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -32,7 +32,7 @@
 #include "tcutil.h"
 
 #define BSON_IS_NUM_TYPE(atype) (atype == BSON_INT || atype == BSON_LONG || atype == BSON_DOUBLE)
-#define BSON_IS_STRING_TYPE(atype) (atype == BSON_STRING || atype == BSON_SYMBOL) 
+#define BSON_IS_STRING_TYPE(atype) ((atype) == BSON_STRING || (atype) == BSON_SYMBOL) 
 
 EJDB_EXTERN_C_START
 

--- a/src/ejdb/ejdb.c
+++ b/src/ejdb/ejdb.c
@@ -1794,10 +1794,11 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
     int sp;
     const char *fval;
 
+	// Feature #129: Handle BSON_SYMBOL like BSON_STRING
 #define _FETCHSTRFVAL() \
     do { \
-        fvalsz = (bt == BSON_STRING) ? bson_iterator_string_len(it) : 1; \
-        fval = (bt == BSON_STRING) ? bson_iterator_string(it) : ""; \
+        fvalsz = (BSON_IS_STRING_TYPE(bt)) ? bson_iterator_string_len(it) : 1; \
+        fval = (BSON_IS_STRING_TYPE(bt)) ? bson_iterator_string(it) : ""; \
         if (bt == BSON_OID) { \
             bson_oid_to_string(bson_iterator_oid(it), oidbuf); \
             fvalsz = 25; \
@@ -1824,7 +1825,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
     switch (qf->tcop) {
         case TDBQCSTREQ: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1842,7 +1843,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTRINC: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1860,7 +1861,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTRBW: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1878,7 +1879,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTREW: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1898,7 +1899,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1918,7 +1919,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1938,7 +1939,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1986,7 +1987,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
+            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);

--- a/src/ejdb/ejdb.c
+++ b/src/ejdb/ejdb.c
@@ -1825,7 +1825,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
     switch (qf->tcop) {
         case TDBQCSTREQ: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1843,7 +1843,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTRINC: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1861,7 +1861,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTRBW: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1879,7 +1879,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
         }
         case TDBQCSTREW: {
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1899,7 +1899,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1919,7 +1919,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1939,7 +1939,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);
@@ -1987,7 +1987,7 @@ static bool _qrybsvalmatch(const EJQF *qf, bson_iterator *it, bool expandarrays,
             TCLIST *tokens = qf->exprlist;
             assert(tokens);
             _FETCHSTRFVAL();
-            if ((qf->flags & EJCONDICASE) && (BSON_IS_STRING_TYPE(bt))) {
+            if ((qf->flags & EJCONDICASE) && (bt == BSON_STRING)) {
                 cbufstrlen = tcicaseformat(fval, fvalsz - 1, sbuf, JBSTRINOPBUFFERSZ, &cbuf);
                 if (cbufstrlen < 0) {
                     _ejdbsetecode(qf->jb, cbufstrlen, __FILE__, __LINE__, __func__);

--- a/src/ejdb/tests/ejdbtest2.c
+++ b/src/ejdb/tests/ejdbtest2.c
@@ -2576,6 +2576,7 @@ void testQuery28(void) { // $gte: 64 bit number
     bson_init_as_query(&bsq1);
 	bson_append_start_object(&bsq1, "longscore");
     bson_append_long(&bsq1, "$gte", int64value);
+    bson_append_finish_object(&bsq1);
     bson_finish(&bsq1);
     CU_ASSERT_FALSE_FATAL(bsq1.err);
 
@@ -2614,6 +2615,7 @@ void testQuery29(void) {
     bson_init_as_query(&bsq1);
 	bson_append_start_object(&bsq1, "symbol_info");
     bson_append_symbol(&bsq1, "$begin", "app");
+    bson_append_finish_object(&bsq1);
     bson_finish(&bsq1);
     CU_ASSERT_FALSE_FATAL(bsq1.err);
 
@@ -2623,7 +2625,8 @@ void testQuery29(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    fprintf(stderr, "%s", TCXSTRPTR(log));
+	fprintf(stderr, "RESULT count=%d\n", count);
 
     CU_ASSERT_EQUAL(count, 2);  // should match symbol_info: apple, application
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 2);
@@ -2651,7 +2654,8 @@ void testQuery30(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    fprintf(stderr, "%s", TCXSTRPTR(log));
+	fprintf(stderr, "RESULT count=%d\n", count);
 
     CU_ASSERT_EQUAL(count, 1);  // should match symbol_info: bison
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 1);
@@ -2684,7 +2688,8 @@ void testQuery31(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    //fprintf(stderr, "%s", TCXSTRPTR(log));
+    fprintf(stderr, "%s", TCXSTRPTR(log));
+	fprintf(stderr, "RESULT count=%d\n", count);
 
     CU_ASSERT_EQUAL(count, 2);  // should match symbol_info: apple, bison
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 2);

--- a/src/ejdb/tests/ejdbtest2.c
+++ b/src/ejdb/tests/ejdbtest2.c
@@ -63,7 +63,7 @@ void testAddData(void) {
     bson_append_finish_object(&a1);
     bson_append_finish_array(&a1); //EOF complexarr
     CU_ASSERT_FALSE_FATAL(a1.err);
-	bson_append_symbol(&a1, "symbol_info", "apple");
+	bson_append_symbol(&a1, "symbol", "apple");
     bson_finish(&a1);
     ejdbsavebson(ccoll, &a1, &oid);
     bson_destroy(&a1);
@@ -101,7 +101,7 @@ void testAddData(void) {
     bson_append_long(&a1, "1", 556667);
     bson_append_double(&a1, "2", 77676.22);
     bson_append_finish_array(&a1);
-	bson_append_symbol(&a1, "symbol_info", "application");
+	bson_append_symbol(&a1, "symbol", "application");
 
     bson_finish(&a1);
     CU_ASSERT_FALSE_FATAL(a1.err);
@@ -124,7 +124,7 @@ void testAddData(void) {
     bson_append_long(&a1, "1", 222334);
     bson_append_double(&a1, "2", 77676.22);
     bson_append_finish_array(&a1);
- 	bson_append_symbol(&a1, "symbol_info", "bison");
+ 	bson_append_symbol(&a1, "symbol", "bison");
     bson_finish(&a1);
     CU_ASSERT_FALSE_FATAL(a1.err);
 
@@ -2613,8 +2613,8 @@ void testQuery29(void) {
 
     bson bsq1;
     bson_init_as_query(&bsq1);
-	bson_append_start_object(&bsq1, "symbol_info");
-    bson_append_symbol(&bsq1, "$begin", "app");
+    bson_append_start_object(&bsq1, "symbol");
+    bson_append_string(&bsq1, "$begin", "app");
     bson_append_finish_object(&bsq1);
     bson_finish(&bsq1);
     CU_ASSERT_FALSE_FATAL(bsq1.err);
@@ -2625,11 +2625,15 @@ void testQuery29(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    fprintf(stderr, "%s", TCXSTRPTR(log));
-	fprintf(stderr, "RESULT count=%d\n", count);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
 
     CU_ASSERT_EQUAL(count, 2);  // should match symbol_info: apple, application
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 2);
+
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        if (i == 0) CU_ASSERT_FALSE(bson_compare_string("apple", TCLISTVALPTR(q1res, i), "symbol"));
+        if (i == 1) CU_ASSERT_FALSE(bson_compare_string("application", TCLISTVALPTR(q1res, i), "symbol"));
+    }
 
     bson_destroy(&bsq1);
     tclistdel(q1res);
@@ -2644,7 +2648,7 @@ void testQuery30(void) {
 
     bson bsq1;
     bson_init_as_query(&bsq1);
-    bson_append_symbol(&bsq1, "symbol_info", "bison");
+    bson_append_string(&bsq1, "symbol", "bison");
     bson_finish(&bsq1);
     CU_ASSERT_FALSE_FATAL(bsq1.err);
 
@@ -2654,11 +2658,14 @@ void testQuery30(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    fprintf(stderr, "%s", TCXSTRPTR(log));
-	fprintf(stderr, "RESULT count=%d\n", count);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
 
     CU_ASSERT_EQUAL(count, 1);  // should match symbol_info: bison
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 1);
+
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        if (i == 0) CU_ASSERT_FALSE(bson_compare_string("bison", TCLISTVALPTR(q1res, i), "symbol"));
+    }
 
     bson_destroy(&bsq1);
     tclistdel(q1res);
@@ -2673,13 +2680,13 @@ void testQuery31(void) {
 
     bson bsq1;
     bson_init_as_query(&bsq1);
-    bson_append_start_object(&bsq1, "symbol_info");
+    bson_append_start_object(&bsq1, "symbol");
     bson_append_start_array(&bsq1, "$in");
-    bson_append_symbol(&bsq1, "0", "apple");
-    bson_append_symbol(&bsq1, "1", "bison");
+    bson_append_string(&bsq1, "0", "apple");
+    bson_append_string(&bsq1, "1", "bison");
     bson_append_finish_array(&bsq1);
     bson_append_finish_object(&bsq1);
-	bson_finish(&bsq1);
+    bson_finish(&bsq1);
     CU_ASSERT_FALSE_FATAL(bsq1.err);
 
     EJQ *q1 = ejdbcreatequery(jb, &bsq1, NULL, 0, NULL);
@@ -2688,11 +2695,15 @@ void testQuery31(void) {
     uint32_t count = 0;
     TCXSTR *log = tcxstrnew();
     TCLIST *q1res = ejdbqryexecute(contacts, q1, &count, 0, log);
-    fprintf(stderr, "%s", TCXSTRPTR(log));
-	fprintf(stderr, "RESULT count=%d\n", count);
+    //fprintf(stderr, "%s", TCXSTRPTR(log));
 
     CU_ASSERT_EQUAL(count, 2);  // should match symbol_info: apple, bison
     CU_ASSERT_TRUE(TCLISTNUM(q1res) == 2);
+
+    for (int i = 0; i < TCLISTNUM(q1res); ++i) {
+        if (i == 0) CU_ASSERT_FALSE(bson_compare_string("apple", TCLISTVALPTR(q1res, i), "symbol"));
+        if (i == 1) CU_ASSERT_FALSE(bson_compare_string("bison", TCLISTVALPTR(q1res, i), "symbol"));
+    }
 
     bson_destroy(&bsq1);
     tclistdel(q1res);


### PR DESCRIPTION
This is a small change in _qrybsvalmatch() to handle symbol objects (BSON_SYMBOL) like strings. You can now use a string query to search for symbols. Added unit-tests for $begin, $in, and equality checking.