### PR TITLE
Remove ejdb in pkg-config includedir

### DIFF
--- a/src/libejdb.pc.in
+++ b/src/libejdb.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@PROJECT_NAME@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION_SUMMARY@


### PR DESCRIPTION
Because if  CFLAGS from libejdb.pc  are for example. '-I/usr/include/ejdb' , then in source file ejdb headers are included like 

```
#include <ejdb.h>
#include <bson.h>    <--- may cause conflict with other bson libs
```

So better to have separation by project name like

```
#include <ejdb/ejdb.h>
#include <ejdb/bson.h>    <--- Now it is fine
```

Hence remove ejdb folder from includedir path from libejdb.pc.in


Unit test results:

```
100% tests passed, 0 tests failed out of 270

Total Test time (real) = 149.89 sec
```
