### PR TITLE
EJDB_EXPORT for bson_free

### DIFF
--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -1087,7 +1087,7 @@ EJDB_EXPORT int bson_numstrn(char *str, int maxbuf, int64_t i);
 typedef void( *bson_err_handler)(const char *errmsg);
 typedef int (*bson_printf_func)(const char *, ...);
 
-void bson_free(void *ptr);
+EJDB_EXPORT void bson_free(void *ptr);
 
 /**
  * Allocates memory and checks return value, exiting fatally if malloc() fails.


### PR DESCRIPTION
There are functions like `bson2json()` that allocates string, but `bson_free()` symbol isn't exported  to library. Hence no way to free allocated memory and we need EJDB_EXPORT for `bson_free()`


Tests results:
```
100% tests passed, 0 tests failed out of 270
```