### PR TITLE
Add 'safe' variants of bson_init_* functions.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+ejdb (1.2.12) testing; urgency=medium
+
+  *  Fix: "no record found" after creating two collections in a row #174
+  *  Fix: SEGFAULT on sequential open/close with the same handle #169
+
+ -- Adamansky Anton <adam@home>  Tue, 21 Mar 2017 15:57:29 +0700
+
 ejdb (1.2.11) testing; urgency=medium
 
   * EJDB_EXPORT for bson_free fixed #160

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![EJDB](http://ejdb.org/_images/ejdblogo3.png)](http://ejdb.org)
 
-[EJDB v1.2.11 released (2017-16-03)](https://github.com/Softmotions/ejdb/releases/tag/v1.2.11)
+[EJDB v1.2.12 released (2017-21-03)](https://github.com/Softmotions/ejdb/releases/tag/v1.2.12)
 
 Embedded JSON Database engine C library (libejdb)
 =================================================

--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ version of [Tokyo Cabinet](http://fallabs.com/tokyocabinet/).
 JSON representation of queries and data implemented with API based on 
 [C BSON](https://github.com/mongodb/mongo-c-driver/tree/master/src/) 
      
+**[Roadmap and thoughts for the next major EJDB 2.0 release](https://github.com/Softmotions/ejdb/issues/183)**     
      
-### NOTE: libejdb 1.2.x introduces some changes that break compatibility with 1.1.x versions:
-* Library name was changed from `tcejdb9` to `ejdb`
-* Library build system was switched to CMake 
-* [See the full 1.2.3 changelog](https://github.com/Softmotions/ejdb/blob/master/Changelog)
-
-
 Features
 ========
 * LGPL license allows you to embed this library into proprietary software

--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -60,8 +60,9 @@ enum bson_validity_t {
 enum bson_binary_subtype_t {
     BSON_BIN_BINARY = 0,
     BSON_BIN_FUNC = 1,
-    BSON_BIN_BINARY_OLD = 2,
-    BSON_BIN_UUID = 3,
+    BSON_BIN_BINARY_OLD = 2, /**< Deprecated */
+    BSON_BIN_UUID_OLD = 3, /**< Deprecated */
+    BSON_BIN_UUID = 4,
     BSON_BIN_MD5 = 5,
     BSON_BIN_USER = 128
 };
@@ -78,7 +79,7 @@ typedef enum {
     BSON_OBJECT = 3,
     BSON_ARRAY = 4,
     BSON_BINDATA = 5,
-    BSON_UNDEFINED = 6,
+    BSON_UNDEFINED = 6, /**< Deprecated */
     BSON_OID = 7,
     BSON_BOOL = 8,
     BSON_DATE = 9,
@@ -86,7 +87,7 @@ typedef enum {
     BSON_REGEX = 11,
     BSON_DBREF = 12, /**< Deprecated. */
     BSON_CODE = 13,
-    BSON_SYMBOL = 14,
+    BSON_SYMBOL = 14, /**< Deprecated. */
     BSON_CODEWSCOPE = 15,
     BSON_INT = 16,
     BSON_TIMESTAMP = 17,

--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -639,17 +639,47 @@ EJDB_EXPORT int bson_init_data(bson *b, char *data);
 EJDB_EXPORT int bson_init_finished_data(bson *b, const char *data);
 
 /**
- * Initialize a BSON object, and set its
- * buffer to the given size.
+ * Initialize a BSON object and set its buffer to the given size.
  *
  * @param b the BSON object to initialize.
  * @param size the initial size of the buffer.
- *
- * @return BSON_OK or BSON_ERROR.
  */
 EJDB_EXPORT void bson_init_size(bson *b, int size);
 
 EJDB_EXPORT void bson_init_on_stack(bson *b, char *bstack, int mincapacity, int maxonstack);
+
+/**
+ * Initialize a BSON object. If not created with bson_new, you must
+ * initialize each new bson object using this function. Report
+ * problems with memory allocation.
+ *
+ * @param b the BSON object to initialize.
+ *
+ * @return BSON_OK or BSON_ERROR.
+ */
+EJDB_EXPORT int bson_safe_init(bson *b);
+
+/**
+ * Initialize a BSON object and set its buffer to the given size.
+ * Report problems with memory allocation.
+ *
+ * @param b the BSON object to initialize.
+ * @param size the inintial size of the buffer.
+ *
+ * @return BSON_OK or BSON_ERROR.
+ */
+EJDB_EXPORT int bson_safe_init_size(bson *b, int size);
+
+/**
+ * Intialize a BSON object. In query contruction mode allowing dot and
+ * dollar chars in field names. Report problems with memory
+ * allocation.
+ *
+ * @param b
+ *
+ * @return BSON_OK or BSON_ERROR
+ */
+EJDB_EXPORT int bson_safe_init_as_query(bson *b);
 
 /**
  * Grow a bson object.


### PR DESCRIPTION
bson_safe_init_* call bson_ensure_sapce() and return error, if
memory allocation has failed.

Signed-off-by: Łukasz Stelmach <l.stelmach@samsung.com>