### PR TITLE
add missing dependency

### DIFF
--- a/src/bindings/ejdb2_node/package.json
+++ b/src/bindings/ejdb2_node/package.json
@@ -38,7 +38,8 @@
     "gauge": "^2.7.4",
     "request": "^2.88.0",
     "request-progress": "^3.0.0",
-    "rimraf": "^2.6.3"
+    "rimraf": "^2.6.3",
+    "semver": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.10",


### PR DESCRIPTION
ejdb2_node uses `semver` module which is missing after install