### PR TITLE
docs: fix simple typo, databse -> database

### DIFF
--- a/src/bindings/ejdb2_node/index.js
+++ b/src/bindings/ejdb2_node/index.js
@@ -451,7 +451,7 @@ class JQL {
 class EJDB2 {
 
   /**
-   * Open databse instance.
+   * Open database instance.
    *
    * @param {String} path Path to database
    * @param {Object} [opts]

--- a/src/bindings/ejdb2_react_native/binding/index.js
+++ b/src/bindings/ejdb2_react_native/binding/index.js
@@ -421,7 +421,7 @@ class JQL {
  */
 class EJDB2 {
   /**
-   * Open databse instance.
+   * Open database instance.
    *
    * @param {string} path Path to database
    * @param {Object} [opts]

--- a/src/tests/ejdb_test1.c
+++ b/src/tests/ejdb_test1.c
@@ -274,7 +274,7 @@ void ejdb_test1_1() {
   rc = ejdb_close(&db);
   CU_ASSERT_EQUAL_FATAL(rc, 0);
 
-  // Now reopen databse then load collection
+  // Now reopen database then load collection
   opts.kv.oflags &= ~IWKV_TRUNC;
   rc = ejdb_open(&opts, &db);
   CU_ASSERT_EQUAL_FATAL(rc, 0);


### PR DESCRIPTION
There is a small typo in src/bindings/ejdb2_node/index.js, src/bindings/ejdb2_react_native/binding/index.js, src/tests/ejdb_test1.c.

Should read `database` rather than `databse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md