### PR TITLE
Update debian/compat to version 13

### DIFF
--- a/cmake/Modules/UploadPPA.cmake
+++ b/cmake/Modules/UploadPPA.cmake
@@ -207,7 +207,7 @@ execute_process(COMMAND chmod +x ${debian_rules})
 
 ##############################################################################
 # debian/compat
-file(WRITE ${DEBIAN_SOURCE_DIR}/debian/compat "7")
+file(WRITE ${DEBIAN_SOURCE_DIR}/debian/compat "13")
 
 ##############################################################################
 # debian/source/format


### PR DESCRIPTION
Compat version 13 is currently the recommended one.

An important change introduced in 10 was change of default to target parallel builds

https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/debhelper.pod#compatibility-levels