### PR TITLE
Update link to iowow library

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EJDB2 is an embeddable JSON database engine published under MIT license.
   * [rfc7386](https://tools.ietf.org/html/rfc7386) JSON Merge patch
   * [rfc6901](https://tools.ietf.org/html/rfc6901) JSON Path
 * [Support of collection joins](#jql-collection-joins)
-* Powered by [iowow.io](http://iowow.io) - The persistent key/value storage engine
+* Powered by [iowow](https://iowow.softmotions.com/) - The persistent key/value storage engine ([repository](https://github.com/Softmotions/iowow))
 * HTTP REST/Websockets endpoints powered by [IWNET](https://github.com/Softmotions/iwnet) and [BearSSL](https://github.com/Softmotions/BearSSL).
 * JSON documents are stored in using fast and compact [binn](https://github.com/liteserver/binn) binary format
 


### PR DESCRIPTION
Since iowow.io is completely offline, I updated to the new domain and added a direct link to iowow's repository, avoiding future problems in case the official website becomes inaccessible and/or changes its address again.