### PR TITLE
Fix macOS anchor link and name case

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ EJDB2 is an embeddable JSON database engine published under MIT license.
 ---
 * [Native language bindings](#native-language-bindings)
 * Supported platforms
-  * [macOS](#osx)
+  * [macOS](#macos)
   * [iOS](https://github.com/Softmotions/EJDB2Swift)
   * [Linux](#linux)
   * [Android](#android)
@@ -109,7 +109,7 @@ Are you using EJDB? [Let me know!](mailto:info@softmotions.com)
 
 EJDB2 code ported and tested on `High Sierra` / `Mojave` / `Catalina`
 
-[EJDB2 Swift binding](https://github.com/Softmotions/EJDB2Swift) for MacOS, iOS and Linux. 
+[EJDB2 Swift binding](https://github.com/Softmotions/EJDB2Swift) for macOS, iOS and Linux. 
 Swift binding is outdated at now. Looking for contributors.
 
 ```


### PR DESCRIPTION
I followed the commit style for messages and left it reading "* Docs", similar to the majority of other commits that change `README.md`. I'm happy to change any aspect of this PR.