### PR TITLE
Bugfix. set errno=0 before calling strtoll.

### DIFF
--- a/src/jql/inc/jqpx.c
+++ b/src/jql/inc/jqpx.c
@@ -164,9 +164,13 @@ static union jqp_unit* _jqp_string(yycontext *yy, jqp_string_flavours_t flavour,
 static union jqp_unit* _jqp_number(yycontext *yy, jqp_int_flavours_t flavour, const char *text) {
   union jqp_unit *unit = _jqp_unit(yy);
   char *eptr;
+
+  // strtoll does not set errno=0 on success, so reset it before calling
+  errno = 0;
+
   int64_t ival = strtoll(text, &eptr, 0);
   if ((eptr == text) || (errno == ERANGE)) {
-    iwlog_error("Invalid number: %s", text);
+    iwlog_error("Invalid number: %s = %lld", text,ival);
     JQRC(yy, JQL_ERROR_QUERY_PARSE);
   }
   if ((*eptr == '.') || (*eptr == 'e') || (*eptr == 'E')) {
@@ -189,6 +193,8 @@ static union jqp_unit* _jqp_json_number(yycontext *yy, const char *text) {
   union jqp_unit *unit = _jqp_unit(yy);
   char *eptr;
   unit->type = JQP_JSON_TYPE;
+  // strtoll does not set errno=0 on success, so reset it before calling
+  errno = 0;
   int64_t ival = strtoll(text, &eptr, 0);
   if ((eptr == text) || (errno == ERANGE)) {
     iwlog_error("Invalid number: %s", text);


### PR DESCRIPTION
Was getting erroneous parsing errors from _jqp_number(). 
If errno was already set to ERANGE when function was called it would always report "Invalid number" and fail.
This is because strtoll() does not set errno=0 on success.
The fix is to set errno=0 before calling strotoll().