### PR TITLE
jbi: fix 1-byte heap buffer overflow in jbi_node_expr_matched()

### DIFF
--- a/src/jbi/jbi_util.c
+++ b/src/jbi/jbi_util.c
@@ -251,12 +251,12 @@ bool jbi_node_expr_matched(JQP_AUX *aux, JBIDX idx, IWKV_cursor cur, JQP_EXPR *e
   rc = iwkv_cursor_copy_key(cur, kbuf, sizeof(skey) - 1, &sz, 0);
   RCGO(rc, finish);
   if (sz > sizeof(skey) - 1) {
-    kbuf = malloc(sz);
+    kbuf = malloc(sz + 1);
     if (!kbuf) {
       rc = iwrc_set_errno(IW_ERROR_ALLOC, errno);
       goto finish;
     }
-    rc = iwkv_cursor_copy_key(cur, kbuf, sizeof(skey) - 1, &sz, 0);
+    rc = iwkv_cursor_copy_key(cur, kbuf, sz, &sz, 0);
     RCGO(rc, finish);
   }
   if (idx->mode & EJDB_IDX_STR) {


### PR DESCRIPTION
## Bug

In `src/jbi/jbi_util.c`, `jbi_node_expr_matched()` uses a 1024-byte stack
buffer (`skey`) to copy an index key via `iwkv_cursor_copy_key()`. When the
actual key size `sz` exceeds `sizeof(skey) - 1` (i.e. the indexed
`EJDB_IDX_STR`/`EJDB_IDX_F64` value is longer than 1023 bytes, which is a
normal, reachable state since IOWOW imposes no such limit on index keys),
the code falls back to a heap buffer:

```c
kbuf = malloc(sz);
...
rc = iwkv_cursor_copy_key(cur, kbuf, sizeof(skey) - 1, &sz, 0);
```

Later, for `EJDB_IDX_STR`/`EJDB_IDX_F64` modes:

```c
kbuf[sz] = '\0';
```

`kbuf` only has `sz` bytes (valid indices `0..sz-1`), so writing to
`kbuf[sz]` is exactly one byte past the end of the allocation — a classic
off-by-one heap buffer overflow (CWE-193 / CWE-787).

This path is reachable through ordinary index-scan consumption
(`jbi_dup_scanner.c` / `jbi_uniq_scanner.c`) whenever a compound/secondary
filter or prefix match is evaluated against a `EJDB_IDX_STR`/`EJDB_IDX_F64`
index and the indexed value is longer than 1023 bytes.

I reproduced this locally with a guard-page harness (allocating the
`malloc(sz)`-equivalent block immediately before a `PAGE_NOACCESS` guard
page): the `kbuf[sz] = '\0'` write reliably segfaults, and the crash
disappears once the allocation is `sz + 1` bytes.

## Fix

- `malloc(sz)` -> `malloc(sz + 1)` so there is room for the NUL terminator
  written at `kbuf[sz]`.
- The second `iwkv_cursor_copy_key()` call still passed the stale
  `sizeof(skey) - 1` (1023) as `kbufsz`, which would truncate the copy to
  the first 1023 bytes even though `kbuf` is now large enough for the full
  key — bytes `[1023..sz-1]` would remain uninitialized heap memory. This
  change passes `sz` instead so the full key is actually copied into the
  larger buffer.